### PR TITLE
Fix wrong library case

### DIFF
--- a/kernel/RealDI.c
+++ b/kernel/RealDI.c
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 #include "debug.h"
-#include "config.h"
+#include "Config.h"
 #include "common.h"
 #include "string.h"
 #include "alloc.h"


### PR DESCRIPTION
And also fix compilation issues on case-sensitive file systems such as Linux ext2/3/4 or OS X HFS+ (with case-sensitive enabled).