### PR TITLE
Create controller_Gravis_Eliminator_AfterShock.ini

### DIFF
--- a/controllerconfigs/controller_Gravis_Eliminator_AfterShock.ini
+++ b/controllerconfigs/controller_Gravis_Eliminator_AfterShock.ini
@@ -1,0 +1,56 @@
+[Gravis Eliminator AfterShock]
+VID=047D
+PID=4006
+Polltype=1
+DPAD=1
+B=6,02
+A=6,04
+Y=6,01
+X=6,08
+L=6,10
+ZL=6,40
+Z=6,80
+R=6,20
+S=7,02
+Power=7,03
+Left=4,00
+Down=5,FF
+Right=4,FF
+Up=5,00
+StickX=0
+StickY=1
+CStickX=3
+CStickY=2
+DigitalLR=1
+LAnalog=0
+RAnalog=0
+Rumble=1
+RumbleType=0
+RumbleDataLen=05
+RumbleDataOn=01,00,00,7F,7F
+RumbleDataOff=01,00,00,00,00
+RumbleTransferLen=05
+RumbleTransfers=1
+
+#Gravis Eliminator AfterShock for Nintendon't
+#---------------------------------------------
+#Controller Type: Arcade-style/dual-analog gamepad (like DualShock 2)
+#Rumble Support: Force Feedback
+#Special Features: Analog sticks, D-pad, precision control toggles
+#Note: This controller is probably common for Windows 95-98 & up.
+
+#Button Setup:
+#  D-Pad: GameCube D-Pad
+#  Left Control Stick: Control Stick
+#  Right Control Stick: C Stick
+#  Button 1: Y
+#  Button 2: B
+#  Button 3: A
+#  Button 4: X
+#  Button 5: L
+#  Button 6: R
+#  Button 7: Half shoulder button force
+#  Button 8: Z
+#  Button 9: unused
+#  Button 10: Start/Pause
+#  Button 9 & Button 10: Power


### PR DESCRIPTION
Gravis Eliminator AfterShock for Nintendon't

Controller Type: Arcade-style/dual-analog gamepad (like DualShock 2)
Rumble Support: Force Feedback
Special Features: Analog sticks, D-pad, precision control toggles
Note: This controller is probably common for Windows 95-98 & up.