### PR TITLE
Create controller_Gravis_Eliminator_GamePad_Pro.ini

### DIFF
--- a/controllerconfigs/controller_Gravis_Eliminator_GamePad_Pro.ini
+++ b/controllerconfigs/controller_Gravis_Eliminator_GamePad_Pro.ini
@@ -1,0 +1,59 @@
+[Gravis Eliminator GamePad Pro]
+VID=047D
+PID=4005
+Polltype=1
+DPAD=0
+Power=3,03
+A=2,04
+B=2,02
+X=2,08
+Y=2,01
+Z=2,20
+L=2,40
+R=2,80
+S=3,02
+#Left=2,26
+#Down=2,24
+#Right=2,22
+#Up=2,20
+#RightUp=2,21
+#DownRight=2,23
+#DownLeft=2,25
+#UpLeft=2,27
+StickX=0
+StickY=1
+#CStickX=5
+#CStickY=6
+DigitalLR=1
+LAnalog=0
+RAnalog=0
+
+#Gravis Eliminator GamePad Pro for Nintendon't
+#---------------------------------------------
+#Controller Type: Arcade/Retro gamepad
+#Rumble Support: None
+#Special Features: Analog D-pad, precision control toggle
+
+#Button Setup:
+#  D-Pad: Control Stick
+#  Button 1: Y
+#  Button 2: B
+#  Button 3: A
+#  Button 4: X
+#  Button 5: unused (Full shoulder button force)
+#  Button 6: Z
+#  Button 7: L
+#  Button 8: R
+#  Button 9: unused
+#  Button 10: Start/Pause
+#  Button 9 & Button 10: Power
+
+#Recommended Games:
+#  * Ikaruga
+#  * Chaos Field Expanded
+#  * Mobile Light Force 2 / Castle of Shikigami
+#  * Capcom vs. SNK EO
+#  * Rave Master
+#  * Super Smash Bros. Melee
+#  * Sonic Gems Collection
+#  * Sonic Mega Collection


### PR DESCRIPTION
Gravis Eliminator GamePad Pro for Nintendon't

Controller Type: Arcade/Retro gamepad
Rumble Support: None
Special Features: Analog D-pad, precision control toggle