### PR TITLE
Add Generic USB Gamepad PID=0810 VID=e501

### DIFF
--- a/controllerconfigs/controller_Generic_USB_Gamepad_PID=0810_VID=e501.ini
+++ b/controllerconfigs/controller_Generic_USB_Gamepad_PID=0810_VID=e501.ini
@@ -1,0 +1,52 @@
+[Generic USB Gamepad]
+VID=0810
+PID=e501
+
+# Polltype: Use 1 (so far only the ps3 controller needed 0)
+Polltype=1
+DigitalLR=1
+
+# [Button]=[offset],[mask]
+X=5,10
+A=5,20
+B=5,40
+Y=5,80
+
+# L, R, Z left, Z right
+L=6,01
+R=6,02
+ZL=6,04
+Z=6,08
+
+# Select, Start
+Power=6,10
+S=6,20
+
+# Certain Pads use BITs for each dpad direction other use numbers going form 0 to 7 for each direction.
+# An easy test for this is if one direction doesn't change any bits then use 1 and fill in all 8 values
+# for the DPAD otherwise use 0 and just fill in the four values.
+# (the stick value for center is 7F and the extreme values can be mapped to dpad instead if desired)
+#DPAD=1
+#Right=3,FF
+#Left=3,00
+#Down=4,FF
+#Up=4,00
+
+# Composite directions have 2 values modified simultaneously so can't be configured
+# Center position is xx xx xx 7F 7F xx xx xx xx
+# 3,FF FF
+#DownRight=
+# 3,00 FF
+#DownLeft=
+# 3,00 00
+#UpLeft=
+# 3,FF 00
+#RightUp=
+
+StickX=3,0,100
+StickY=4,0,100
+
+# When the stick is missing the value is fixed at 80
+CStickX=1
+CStickY=2
+


### PR DESCRIPTION
Config for common cheap Generic USB Gamepads PID=0810 VID=e501 found on ebay/aliexpress
![ps usb](https://user-images.githubusercontent.com/14217781/66269623-e9d84700-e84a-11e9-8293-44e58f79e042.jpg) ![snes usb](https://user-images.githubusercontent.com/14217781/66269624-e9d84700-e84a-11e9-8b2c-dac82531e69c.jpg)
