### PR TITLE
USB Controller Support for Power A PS3 Wired Controller

### DIFF
--- a/controllerconfigs/controller_PowerA_Wired_PS3.ini
+++ b/controllerconfigs/controller_PowerA_Wired_PS3.ini
@@ -1,0 +1,49 @@
+[POWER A WIRED PS3 Controller]
+# Model Num: 1429765-01
+
+VID=20D6
+PID=CA6D
+
+Polltype=1
+DPAD=1
+
+# Enable Analog triggers
+DigitalLR=2
+
+MultiIn=0
+MultiInValue=01
+
+# PS3 "Home" Button
+Power=1,10
+
+A=0,02
+B=0,01
+X=0,04
+Y=0,08
+Z=0,20
+L=11,F0
+R=12,F0
+
+# Start
+S=1,02
+
+# DPad
+Left=2,06
+Down=2,04
+Right=2,02
+Up=2,00
+RightUp=2,01
+DownRight=2,03
+DownLeft=2,05
+UpLeft=2,07
+
+# Left Analog Stick
+StickX=3
+StickY=4
+
+# Right Analog Stick
+CStickX=5
+CStickY=6
+
+LAnalog=11
+RAnalog=12 


### PR DESCRIPTION
The ini file for the wired Power A PS3 controller to enable Nintendont support.