### PR TITLE
USB HID issue since September 2019 build

### DIFF
--- a/kernel/HID.c
+++ b/kernel/HID.c
@@ -1062,6 +1062,6 @@ void HIDUpdateRegisters(u32 LoaderRequest)
 				}
 			}
 		}
-		HID_Timer = read32(HW_TIMER);
+		//HID_Timer = read32(HW_TIMER);
 	}
 }


### PR DESCRIPTION
https://github.com/FIX94/Nintendont/issues/712

this commit works: https://github.com/FIX94/Nintendont/commit/f0694cd68c126ada84fda81307639b3d4e3f72e4
but the next commit has the freeze issue: https://github.com/FIX94/Nintendont/commit/274699000ccf0b6b8e5fbb8a5cbb50a8272334f4

so something in https://github.com/FIX94/Nintendont/commit/274699000ccf0b6b8e5fbb8a5cbb50a8272334f4 is related... i think..

i narrowed it down to that line that was added.

I have no idea why this fixed the issue nor do I know
what other potential problems it introduces but it seems to be working

The intention of this PR is not to actually have this line commented out - but rather to draw attention to the issue. The code in this commit/PR is a workaround and potential fix.

Maybe commenting the line out is a good fix, maybe not - but it is a workaround for people who want to use the latest codebase without breaking usbloaderGX. The other option many people are using is simply using a build from prior to this line being introduced. it is probably better if they use the latest codebase, with that line commented out, and if they find any issues then we can investigate further. Anyway, this PR is to document the line I believe introduced the problem even though just commenting the line out may not be the actual fix in the end.