### PR TITLE
Adding 1 generic GC adapter and 1 Genius controller.

### DIFF
--- a/controllerconfigs/controller_Generic_GC Controller Adapter.ini
+++ b/controllerconfigs/controller_Generic_GC Controller Adapter.ini
@@ -1,0 +1,46 @@
+; Configuration file made for 'Generic GC Controller Adapter' device.
+; The label behind this contained the following information -
+; 'GC Controller Adapter For Switch/Wii U/PC ITEM TO HS-SW305'
+; Device must be set in 'PC' mode.
+; Made by cesarmades.
+
+[Generic GC Controller Adapter]
+VID=0079
+PID=1846
+
+Polltype=1
+
+; Multiple input (several ports). Don't know if it's the same settings for 2 ports than 4 ports.
+MultiIn=1
+MultiInValue=01
+
+A=1,02
+B=1,04
+X=1,01
+Y=1,08
+
+Z=1,80
+
+; Notes from what was seen in other files:
+; 1 = Typical Digital input | 2 = Mix of both?
+DigitalLR=2
+L=1,10
+R=1,20
+LAnalog=7
+RAnalog=8
+
+; Power=
+S=2,02
+
+; Similar to the HID2VPAD functions:
+; 0 = NORMAL | 1 = HAT | etc
+DPAD=0
+Left=2,80
+Right=2,20
+Up=2,10
+Down=2,40
+
+StickX=3
+StickY=4
+CStickX=6
+CStickY=5

--- a/controllerconfigs/controller_Genius_MaxFire G-12UV.ini
+++ b/controllerconfigs/controller_Genius_MaxFire G-12UV.ini
@@ -1,0 +1,38 @@
+[Genius MaxFire G-12U VIBRATION]
+VID=0583
+PID=A009
+Polltype=1
+DPAD=1
+DigitalLR=1
+
+; 1
+A=5,01
+; 3
+B=5,04
+; 2
+X=5,02
+; 4
+Y=5,08
+; 6
+Z=5,20
+; 7
+L=5,40
+; 8
+R=5,80
+; 10
+S=6,02
+
+Left=4,06
+Down=4,04
+Right=4,02
+Up=4,00
+RightUp=4,01
+DownRight=4,03
+DownLeft=4,05
+UpLeft=4,07
+
+StickX=0
+StickY=1
+
+CStickX=2
+CStickY=3


### PR DESCRIPTION
Adding support for the following devices:

- GC Controller Adapter For Switch/Wii U/PC ITEM TO HS-SW305 (must be set on PC mode).
- Genius MaxFire G-12U VIBRATION