### PR TITLE
Fix options wraparound

### DIFF
--- a/loader/source/menu.c
+++ b/loader/source/menu.c
@@ -1174,7 +1174,7 @@ static bool UpdateSettingsMenu(MenuCtx *ctx)
 			if (ctx->settings.settingPart == 0) {
 				ctx->settings.posX = NIN_SETTINGS_LAST - 1;
 			} else {
-				ctx->settings.posX = 7;
+				ctx->settings.posX = 8;
 			}
 		}
 


### PR DESCRIPTION
When the option for configuring the Wii U Gamepad controller slot was added, it was forgotten to adjust the wraparound check, so if one pushes UP to leave the first option, the newly added option will be skipped. This fixes it.