### PR TITLE
Always default to English if the game is not European

### DIFF
--- a/loader/source/main.c
+++ b/loader/source/main.c
@@ -1028,27 +1028,32 @@ int main(int argc, char **argv)
 //Set Language
 	if(ncfg->Language == NIN_LAN_AUTO || ncfg->Language >= NIN_LAN_LAST)
 	{
-		switch (CONF_GetLanguage())
+		if(BI2region == BI2_REGION_PAL)
 		{
-			case CONF_LANG_GERMAN:
-				ncfg->Language = NIN_LAN_GERMAN;
-				break;
-			case CONF_LANG_FRENCH:
-				ncfg->Language = NIN_LAN_FRENCH;
-				break;
-			case CONF_LANG_SPANISH:
-				ncfg->Language = NIN_LAN_SPANISH;
-				break;
-			case CONF_LANG_ITALIAN:
-				ncfg->Language = NIN_LAN_ITALIAN;
-				break;
-			case CONF_LANG_DUTCH:
-				ncfg->Language = NIN_LAN_DUTCH;
-				break;
-			default:
-				ncfg->Language = NIN_LAN_ENGLISH;
-				break;
+			switch (CONF_GetLanguage())
+			{
+				case CONF_LANG_GERMAN:
+					ncfg->Language = NIN_LAN_GERMAN;
+					break;
+				case CONF_LANG_FRENCH:
+					ncfg->Language = NIN_LAN_FRENCH;
+					break;
+				case CONF_LANG_SPANISH:
+					ncfg->Language = NIN_LAN_SPANISH;
+					break;
+				case CONF_LANG_ITALIAN:
+					ncfg->Language = NIN_LAN_ITALIAN;
+					break;
+				case CONF_LANG_DUTCH:
+					ncfg->Language = NIN_LAN_DUTCH;
+					break;
+				default:
+					ncfg->Language = NIN_LAN_ENGLISH;
+					break;
+			}
 		}
+		else
+			ncfg->Language = NIN_LAN_ENGLISH;
 	}
 if( ncfg->GameID == 0x47464f45 )	// The Fairly OddParents: Shadow Showdown
 	{


### PR DESCRIPTION
Forcing a non-European game to an European language can have some funny side-effects, so it's better to prevent that if the language setting is Auto.