### PR TITLE
Change language in F-Zero AX

### DIFF
--- a/kernel/TRI.c
+++ b/kernel/TRI.c
@@ -354,7 +354,10 @@ void TRISetupGames()
 	{
 		dbgprintf("TRI:F-Zero AX (Rev C)\r\n");
 		TRIGame = TRI_AX;
-		SystemRegion = REGION_JAPAN;
+		if(ncfg->Language == NIN_LAN_ENGLISH)
+			SystemRegion = REGION_EXPORT;
+		else
+			SystemRegion = REGION_JAPAN;
 		AXTimerOffset = 0x003CD1C0;
 		TRISettingsName = SETTINGS_AX_RVC;
 		TRISettingsLoc = 0x3CF6F0;
@@ -386,9 +389,6 @@ void TRISetupGames()
 
 		//Remove Overscan on first VIConfigure
 		write32( 0x001FB998, 0x38C00000 );
-
-		//English
-		write32( 0x000DF430, 0x38000000 );
 
 		if(!arcadeMode)
 		{
@@ -437,7 +437,10 @@ void TRISetupGames()
 	{
 		dbgprintf("TRI:F-Zero AX (Rev D)\r\n");
 		TRIGame = TRI_AX;
-		SystemRegion = REGION_JAPAN;
+		if(ncfg->Language == NIN_LAN_ENGLISH)
+			SystemRegion = REGION_EXPORT;
+		else
+			SystemRegion = REGION_JAPAN;
 		AXTimerOffset = 0x003CD6A0;
 		TRISettingsName = SETTINGS_AX_RVD;
 		TRISettingsLoc = 0x3CFBD0;
@@ -479,9 +482,6 @@ void TRISetupGames()
 
 		//Remove Overscan on first VIConfigure
 		write32( 0x001FBE54, 0x38C00000 );
-
-		//English
-		write32( 0x000DF698, 0x38000000 );
 
 		if(!arcadeMode)
 		{
@@ -531,7 +531,10 @@ void TRISetupGames()
 	{
 		dbgprintf("TRI:F-Zero AX (Rev E)\r\n");
 		TRIGame = TRI_AX;
-		SystemRegion = REGION_JAPAN;
+		if(ncfg->Language == NIN_LAN_ENGLISH)
+			SystemRegion = REGION_EXPORT;
+		else
+			SystemRegion = REGION_JAPAN;
 		AXTimerOffset = 0x003CDC20;
 		TRISettingsName = SETTINGS_AX_RVE;
 		TRISettingsLoc = 0x3D0150;
@@ -570,10 +573,7 @@ void TRISetupGames()
 
 		//Remove Overscan on first VIConfigure
 		write32( 0x001FC2C4, 0x38C00000 );
-
-		//English
-		write32( 0x000DF818, 0x38000000 );
-
+		
 		if(!arcadeMode)
 		{
 			//Remove some menu timers (thanks dj_skual)


### PR DESCRIPTION
If the Language setting is English, the game will be in English. If not, it will be in Japanese.
Also, the way the game will be set to English is now more proper, as it will no longer bruteforce a value into a memory address but it changes the emulated Triforce system's regional setting. As a result, some text legibility in English will be fixed (e.g., the Drift Turn text box in the Attract mode will no longer go out of the screen's bounds).

To avoid weird behaviour when the Language setting is Auto, it's better to implement the "Always default to English if the game is not European" pull request as well.