### PR TITLE
Virtua Striker 4 Japanese version fix

### DIFF
--- a/kernel/TRI.c
+++ b/kernel/TRI.c
@@ -97,6 +97,14 @@ void TRIReset()
 		W16((u32)OUR_SETTINGS_LOC+0x16,150);
 		sync_after_write(OUR_SETTINGS_LOC, 0x20);
 	}
+	//Virtua Striker 4 Japanese version fix
+	if(TRISettingsName == SETTINGS_VS4JAP)
+    	{
+        	//Disable Network
+		sync_before_read(OUR_SETTINGS_LOC, 0x20);
+		W16((u32)OUR_SETTINGS_LOC+0x10,0);
+		sync_after_write(OUR_SETTINGS_LOC, 0x20);
+    	}
 }
 
 void TRIBackupSettings()


### PR DESCRIPTION
In the Japanese version of Virtua Striker 4 (the original version, not ver. 2006), if you simply push Start right after calibrating the analog stick, the game will crash. This is because the Network option is enabled by default, and Triforce networking is currently not emulated. (Instead of pushing Start, you can enter Test mode and disable the Network option, but that's a pain in the ass.)

This issue does not occur with Ver. 2006 because Nintendont is hardcoded to disable that option even if you turn it on: to achieve this, the memory address at line 782 (the one with the comment "don't wait for other cabinets to link up") was altered. But since I don't own a debugging tool for Wii, I couldn't find such memory address, so I took another approach: I compared different saves with an hex editor, found that the Network setting is at the 0x10 offset, then made the option Off by default. (Value 01 is on, value 00 is off.)