### PR TITLE
Possible fix to nincfg.bin update path

### DIFF
--- a/loader/source/global.c
+++ b/loader/source/global.c
@@ -339,6 +339,17 @@ bool LoadNinCFG(void)
 				ConfigLoaded = false;
 			break;
 
+		case 3:
+		case 4:
+		case 5:
+		case 6:
+		case 7:
+		case 8:
+		case 9:
+			if (BytesRead != 540)
+				ConfigLoaded = false;
+			break;
+
 		default:
 			if (BytesRead != sizeof(NIN_CFG))
 				ConfigLoaded = false;

--- a/loader/source/global.c
+++ b/loader/source/global.c
@@ -346,7 +346,7 @@ bool LoadNinCFG(void)
 		case 7:
 		case 8:
 		case 9:
-			if (BytesRead != 540)
+			if (BytesRead != 544)
 				ConfigLoaded = false;
 			break;
 


### PR DESCRIPTION
Since four bytes were added to nincfg.bin in version 10, look for a lower file size when the file is of an older version