### PR TITLE
Add Github Workflow and update README.md

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,0 +1,32 @@
+name: Nintendont Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build Nintendont
+    runs-on: ubuntu-20.04
+    container: devkitpro/devkitppc:latest
+ 
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Build Nintendont dol
+      run: |
+        make -j2
+
+    - name: Copy Nintendont artifacts
+      run: | 
+        mkdir -p dist/Nintendont/apps/Nintendont
+        cp nintendont/icon.png dist/Nintendont/apps/Nintendont/
+        cp nintendont/meta.xml dist/Nintendont/apps/Nintendont/
+        cp loader/loader.dol dist/Nintendont/apps/Nintendont/boot.dol
+
+    - name: Upload Nintendont artifacts
+      uses: actions/upload-artifact@v2
+      with: 
+        name: Nintendont
+        path: |
+         dist/Nintendont/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
-### Nintendont
+## Nintendont
 A Wii Homebrew Project to play GC Games on Wii and vWii on Wii U
+
+### Nightly builds
+
+|Download nightly builds from continuous integration: 	| [![Build Status][Build]][Actions] 
+|-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+
+[Actions]: https://github.com/FIX94/Nintendont/actions
+[Build]: https://github.com/FIX94/Nintendont/workflows/Nintendont%20Build/badge.svg
 
 ### Features:
 * Works on Wii and Wii U (in vWii mode)
@@ -34,6 +42,7 @@ A Wii Homebrew Project to play GC Games on Wii and vWii on Wii U
 
 ### Quick Installation:
 1. Get the [loader.dol](loader/loader.dol?raw=true), rename it to boot.dol and put it in /apps/Nintendont/ along with the files [meta.xml](nintendont/meta.xml?raw=true) and [icon.png](nintendont/icon.png?raw=true).
+   Or go to the Nightly builds [here](https://github.com/FIX94/Nintendont/actions/workflows/continuous-integration-workflow.yml), click on the latest workflow run name, download the file under Artifacts, extract it and put it in /apps/Nintendont/ on your SD card.
 2. Copy your GameCube games to the /games/ directory. Subdirectories are optional for 1-disc games in ISO/GCM and CISO format.
    * For 2-disc games, you should create a subdirectory /games/MYGAME/ (where MYGAME can be anything), then name disc 1 as "game.iso" and disc 2 as "disc2.iso".
    * For extracted FST, the FST must be located in a subdirectory, e.g. /games/FSTgame/sys/boot.bin .


### PR DESCRIPTION
@carnage702 could you please look into this PR.

I've added a Github Workflow, which can provide if you want Nightly Builds and I've updated the README.md to show the status of the build.

An example of the README.md can be seen here:
https://github.com/bladeoner/Nintendont/tree/workflow

When you click on Nintendont Build Passing you will go to the Actions tab where you can see all the runs:
https://github.com/bladeoner/Nintendont/actions

When you click on one of the workflow runs you can see an Artifact with the name Nintendont it contains:
https://github.com/bladeoner/Nintendont/actions/runs/1801911012
- The folder structure /apps/Nintendont
- The boot.dol
- The meta.xml
- And the icon.png

Thanks in advance.