### PR TITLE
Add bug report, feature request and question report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: If you are experiencing an issue, please fill out this form.
+title: "[Issue]: "
+labels: bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug form!
+  - type: textarea
+    id: describe-bug
+    attributes:
+      label: Describe the bug
+      description: Describe the bug as accurately as possible.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Describe the steps to reproduce the bug as accurately as possible.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Add screenshots
+      description: Please add screenshots if available.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-report.yml
+++ b/.github/ISSUE_TEMPLATE/feature-report.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: If you want to have a feature to be added, please fill out this form.
+title: "[Feature request]: "
+labels: enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this feature form!
+  - type: textarea
+    id: feature
+    attributes:
+      label: Describe the feature
+      description: Describe the feature as accurately as possible.
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Add screenshots
+      description: Please add screenshots if available.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question-report.yml
+++ b/.github/ISSUE_TEMPLATE/question-report.yml
@@ -1,0 +1,23 @@
+name: Question
+description: If you have a question, please fill out this form.
+title: "[Question]: "
+labels: question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out the question form!
+  - type: textarea
+    id: question
+    attributes:
+      label: Describe your question
+      description: Describe your question as accurately as possible.
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Add screenshots
+      description: Please add screenshots if available.
+    validations:
+      required: false


### PR DESCRIPTION
I've added a bug, feature request and question report. 

This makes it easier for someone to create an issue or feature request and it makes it also easier for you to distinguish.

When creating a new isssue you will have three options: Bug Report, Feature request, or Question click on Get Started
Bug report:
You need to fill in a title behind [Issue]:
The following are mandatory: Describe the bug, Steps to reproduce, Expected behavior (you see a red star behind the names).
The other two Relevant log output and Add screenshots are optional.

Feature request:
You need to fill in a title behind [Feature request]:
Describe the feature is mandatory, Add screenshots is optional

Question:
You need to fill in a title behind [Question]:
Describe the question is mandatory, Add screenshots is optional

Labels are automatically added.