### PR TITLE
Add CI/CD for nightly builds

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,0 +1,31 @@
+name: Nintendont Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build Nintendont
+    runs-on: ubuntu-latest
+    container: devkitpro/devkitppc:latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Build Nintendont dol
+      run: |
+        make -j2
+        
+    - name: Copy Nintendont artifacts
+      run: | 
+        mkdir -p dist/Nintendont/apps/Nintendont
+        cp nintendont/icon.png dist/Nintendont/apps/Nintendont/
+        cp nintendont/meta.xml dist/Nintendont/apps/Nintendont/
+        cp loader/loader.dol dist/Nintendont/apps/Nintendont/boot.dol
+    - name: Upload Nintendont artifacts
+      uses: actions/upload-artifact@v3
+      with: 
+        name: Nintendont
+        path: |
+         dist/Nintendont/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 ### Nintendont
 A Wii Homebrew Project to play GC Games on Wii and vWii on Wii U
 
+### Nightly builds
+|Download nightly builds from continuous integration: 	| [![Build Status][Build]][Actions] 
+|-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+
+[Actions]: https://github.com/FIX94/Nintendont/actions/workflows/continuous-integration-workflow.yml
+[Build]: https://github.com/FIX94/Nintendont/actions/workflows/continuous-integration-workflow.yml/badge.svg
+
 ### Features:
 * Works on Wii and Wii U (in vWii mode)
 * Full-speed loading from a USB device or an SD card.
@@ -34,6 +41,7 @@ A Wii Homebrew Project to play GC Games on Wii and vWii on Wii U
 
 ### Quick Installation:
 1. Get the [loader.dol](loader/loader.dol?raw=true), rename it to boot.dol and put it in /apps/Nintendont/ along with the files [meta.xml](nintendont/meta.xml?raw=true) and [icon.png](nintendont/icon.png?raw=true).
+   Or go to the Nightly builds [here](https://github.com/FIX94/Nintendont/actions/workflows/continuous-integration-workflow.yml), click on the latest workflow run name, download the file under Artifacts, extract it and put it in /apps/Nintendont/ on your SD card.
 2. Copy your GameCube games to the /games/ directory. Subdirectories are optional for 1-disc games in ISO/GCM and CISO format.
    * For 2-disc games, you should create a subdirectory /games/MYGAME/ (where MYGAME can be anything), then name disc 1 as "game.iso" and disc 2 as "disc2.iso".
    * For extracted FST, the FST must be located in a subdirectory, e.g. /games/FSTgame/sys/boot.bin .


### PR DESCRIPTION
This adds a Github CI/CD pipeline to enable builds after each commit.