### PR TITLE
Fix for issue 643 - Support multiple HID controllers.

### DIFF
--- a/controllerconfigs/controller_psx_ps2_splitter.ini
+++ b/controllerconfigs/controller_psx_ps2_splitter.ini
@@ -1,0 +1,53 @@
+[PSX/PS2 Splitter Controller]
+VID=0925
+PID=8866
+Polltype=1
+DPAD=1
+DigitalLR=1
+MultiIn=4
+MultiInValue=02
+A=1,04
+B=1,08
+X=1,02
+Y=1,01
+Z=1,80
+ZL=1,40
+L=1,10
+R=1,20
+S=2,01
+Power=2,03
+Left=2,60
+Down=2,40
+Right=2,20
+Up=2,00
+RightUp=2,10
+DownRight=2,30
+DownLeft=2,50
+UpLeft=2,70
+StickX=3,1A,100
+StickY=4,1A,100
+CStickX=5,1A,100
+CStickY=6,1A,100
+LAnalog=0
+RAnalog=0
+
+# Generic PSX/PS2 Splitter
+# ------------------------
+# This ini file is for one of those cheap (often blue) PSX/PS2 splitters,
+# which converts one or two, PSX or PS2 controllers into a single USB port.
+# There are lots of them around, with various VID/PID numbers and button layouts, 
+# so you might want to make your own ini file by using crediar's HIDTest homebrew app.
+#
+# The interesting thing about this ini file is that it uses a new "MultiIn=4" mode,
+# which was developed by Gi, in order to allow you to use Nintendont with multiple
+# controllers from splitters like this one, which give their input data as multiple
+# packets (one per controller), instead of a single packet.
+#
+# To get similar splitters to work in Nintendon't, you must: 
+#
+# - Have a splitter that sends 1 packet per controller, in turn, where the
+#   first byte is the index of the controller (starting from 0x01) and the 
+#   maximum packet size in bytes is 32 (you can use HIDTest to confirm this).
+# - Know the VID#, PID# and button details (again you can use HIDTest for this).
+# - Create an ini file for your splitter named VID#_PID#.ini with MultiInValue
+#   set to the number of gamepads the splitter supports and MultiIn set to 4.

--- a/loader/source/ppc/PADReadGC/source/PADReadGC.c
+++ b/loader/source/ppc/PADReadGC/source/PADReadGC.c
@@ -371,7 +371,7 @@ u32 PADRead(u32 calledByGame)
 	if (HIDPad == HID_PAD_NOT_SET)
 		HIDPad = MaxPads;
 
-	for (chan = HIDPad; (chan < HID_PAD_NONE); (HID_CTRL->MultiIn == 3) ? (++chan) : (chan = HID_PAD_NONE)) // Run once unless MultiIn == 3
+	for (chan = HIDPad; (chan < HID_PAD_NONE); (HID_CTRL->MultiIn == 3 || HID_CTRL->MultiIn == 4) ? (++chan) : (chan = HID_PAD_NONE)) // Run once unless MultiIn == 3
 	{
 		if(HIDMemPrep == 0) // first run
 		{
@@ -434,6 +434,20 @@ u32 PADRead(u32 calledByGame)
 					PADIsBarrel[chan] = 0;
 				}
 			}
+		}
+
+		if (HID_CTRL->MultiIn == 4)		// multiple controllers, connected to one usb port via a splitter, merged into a single HID_Packet
+		{
+			if (chan == HID_CTRL->MultiInValue) break; // MultiInValue defines how many controllers we are expecting
+
+			HID_Packet = (vu8*)(0x930050F0 + (chan * 32));	//skip forward how ever many bytes in each controller
+			u32 HID_CacheEndBlock = ALIGN32(((u32)HID_Packet) + 32); //calculate upper cache block used
+			if(HID_CacheEndBlock > HIDMemPrep) //new cache block, prepare memory
+			{
+				memInvalidate = HID_CacheEndBlock;
+				asm volatile("dcbi 0,%0; sync" : : "b"(memInvalidate) : "memory");
+				HIDMemPrep = memInvalidate;
+			}			
 		}
 
 		if(calledByGame && HID_CTRL->Power.Mask &&	//exit if power configured and all power buttons pressed


### PR DESCRIPTION
Hi Nintendont team,

Thank you so much for developing Nintendont.

Please could you consider merging this PR? What it does is to fix issue 643 (related issue 213) and allow us to use splitters like this one (https://m.media-amazon.com/images/W/IMAGERENDERING_521856-T1/images/I/71HtURmbXOL._AC_SX522_.jpg) so we can have multiple gamepads working at the same time.

The splitters can be configured via the ini controller configuration files using a new mode "MultiIn=4". An example ini file called "controller_psx_ps2_splitter.ini" has been added, which works for the PSX/PS2 splitter I have at home.

I decided to introduce a new "MultiIn=4" mode, instead of just changing the code for the existing "MultiIn=2" mode, in case anyone was relying on the existing behavior and because I am using the MultiInValue differently (to represent the number of controllers supported instead of the index of the first controller).

If you need a binary to approve the PR, I have made one at https://github.com/gilesep/Nintendont-gi/releases/tag/v1.0.0.

I am not very familiar with GitHub or contributing to open source projects, so I hope this PR is ok.

Best wishes, Gi