### PR TITLE
Oversized Image Support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,10 +58,11 @@ Changes since v4.406:
 * File extensions .iso, .gcm, .cso, and .ciso are supported.
 * The game list now colorizes game names based on their file format:
   * Black: 1:1 full rip
-  * Dark Brown: Shrunken GCM
+  * Dark Brown: Shrunken
   * Green: Extracted FST
   * Blue: CISO
   * Purple: Multi-Game
+  * Dark Yellow: Oversized
 * Fixed an issue where pressing the Home button in the Settings menu after
   changing a setting crashed the loader.
 * Grayed out settings that don't apply to the current system, e.g. Wii U

--- a/kernel/DI.c
+++ b/kernel/DI.c
@@ -590,13 +590,6 @@ void DIUpdateRegisters( void )
 					#endif
 					memcpy( NetworkCMDBuffer + roffset, (void*)Buffer, Length );
 				}
-				// Max GC disc offset
-				if( Offset >= 0x57058000 )
-				{
-					dbgprintf("Unhandled Media Board Write\n");
-					dbgprintf("GCAM:Write( 0x%08x, 0x%08x, 0x%08x )\n", Offset, Length, Buffer|0x80000000 );
-					Shutdown();
-				}
 				DIOK = 2;
 			} break;
 			case 0xAB:
@@ -758,13 +751,6 @@ void DIUpdateRegisters( void )
 				}
 				else
 				{
-					// Max GC disc offset
-					if( Offset >= 0x57058000 )
-					{
-						dbgprintf("Unhandled Read\n");
-						dbgprintf("DIP:DVDRead%02X( 0x%08x, 0x%08x, 0x%08x )\n", DIcommand, Offset, Length, rawAddr );
-						Shutdown();
-					}
 					if( Buffer < 0x01800000 || // Valid GC Buffer
 						rawAddr == 0x931C1800 ) //PSO Ep.III Hack
 					{

--- a/loader/include/menu.h
+++ b/loader/include/menu.h
@@ -34,6 +34,7 @@ typedef enum
 	GIFLAG_FORMAT_FST	= (2 << 0),	// Extracted FST
 	GIFLAG_FORMAT_CISO	= (3 << 0),	// CISO format
 	GIFLAG_FORMAT_MULTI	= (4 << 0),	// Multi-game disc
+	GIFLAG_FORMAT_OVER	= (5 << 0),	// Oversized
 	GIFLAG_FORMAT_MASK	= (7 << 0),
 
 	// Game region. (from bi2.bin)

--- a/loader/source/ShowGameInfo.c
+++ b/loader/source/ShowGameInfo.c
@@ -177,7 +177,7 @@ static void DrawGameInfoScreen(const gameinfo *gi, const MD5VerifyState_t *md5)
 		"Extracted FST",
 		"Compressed ISO (Hermes uLoader format)",
 		"Multi-Game Disc",
-		"Unknown (5)",
+		"Oversized",
 		"Unknown (6)",
 		"Unknown (7)",
 	};

--- a/loader/source/menu.c
+++ b/loader/source/menu.c
@@ -66,7 +66,7 @@ const u32 DiscFormatColors[8] =
 	0x00551AFF,	// Extracted FST
 	0x001A55FF,	// CISO
 	0x551A55FF,	// Multi-Game
-	GRAY,		// undefined
+	0x55551AFF,	// Oversized (dark yellow)
 	GRAY,		// undefined
 	GRAY,		// undefined
 };
@@ -192,6 +192,11 @@ static bool IsDiscImageValid(const char *filename, int discNumber, gameinfo *gi)
 		{
 			// Full 1:1 GameCube image.
 			gi->Flags = GIFLAG_FORMAT_FULL;
+		}
+		else if (in.obj.objsize > 1459978240)
+		{
+			// Oversized GameCube image.
+			gi->Flags = GIFLAG_FORMAT_OVER;
 		}
 		else
 		{
@@ -731,10 +736,11 @@ static bool UpdateGameSelectMenu(MenuCtx *ctx)
 
 		// Print the color codes.
 		PrintFormat(DEFAULT_SIZE, DiscFormatColors[0], MENU_POS_X, MENU_POS_Y + 20*3, "Colors  : 1:1");
-		PrintFormat(DEFAULT_SIZE, DiscFormatColors[1], MENU_POS_X+(14*10), MENU_POS_Y + 20*3, "Shrunk");
-		PrintFormat(DEFAULT_SIZE, DiscFormatColors[2], MENU_POS_X+(21*10), MENU_POS_Y + 20*3, "FST");
-		PrintFormat(DEFAULT_SIZE, DiscFormatColors[3], MENU_POS_X+(25*10), MENU_POS_Y + 20*3, "CISO");
-		PrintFormat(DEFAULT_SIZE, DiscFormatColors[4], MENU_POS_X+(30*10), MENU_POS_Y + 20*3, "Multi");
+		PrintFormat(DEFAULT_SIZE, DiscFormatColors[1], MENU_POS_X+(12*10), MENU_POS_Y + 20*3, "Shrunk");
+		PrintFormat(DEFAULT_SIZE, DiscFormatColors[2], MENU_POS_X+(19*10), MENU_POS_Y + 20*3, "FST");
+		PrintFormat(DEFAULT_SIZE, DiscFormatColors[3], MENU_POS_X+(23*10), MENU_POS_Y + 20*3, "CISO");
+		PrintFormat(DEFAULT_SIZE, DiscFormatColors[4], MENU_POS_X+(28*10), MENU_POS_Y + 20*3, "Multi");
+		PrintFormat(DEFAULT_SIZE, DiscFormatColors[5], MENU_POS_X+(34*10), MENU_POS_Y + 20*3, "Over");
 
 		// Starting position.
 		int gamelist_y = MENU_POS_Y + 20*5 + 10;


### PR DESCRIPTION
Allows Nintendont to play oversized images, just like Swiss.
Resolves https://github.com/FIX94/Nintendont/issues/1183

Many people have made forks of Nintendont for this purpose. I figure why not finally get this in mainline.

Credit to nfsman34, original fork here:
https://github.com/FIX94/Nintendont/compare/master...nfsman34:Nintendont-SonicRiders:master