### PR TITLE
Patch all regions of HomeLand and Nintendo Puzzle Collection

### DIFF
--- a/kernel/Patch.c
+++ b/kernel/Patch.c
@@ -1444,7 +1444,7 @@ void DoPatches( char *Buffer, u32 Length, u32 DiscOffset )
 			PatchBL(PatchCopy(SonicRidersCopy, SonicRidersCopy_size), SONICRIDERS_HOOK_PAL);
 			dbgprintf("Patch:Patched Sonic Riders _Main.rel PAL\r\n");
 		} /* Agressive Timer Patches for Nintendo Puzzle Collection */
-		else if( (GAME_ID) == 0x47505A4A && useipl == 0 )
+		else if( (TITLE_ID) == 0x47505A && useipl == 0 )
 		{
 			u32 t;
 			for(t = 0; t < Length; t+=4) //make sure its patched at all times
@@ -1698,7 +1698,7 @@ void DoPatches( char *Buffer, u32 Length, u32 DiscOffset )
 	{
 		if(TITLE_ID == 0x474D34 || TITLE_ID == 0x474B59 || TITLE_ID == 0x475445)
 			bbaEmuWanted = 1;
-		else if(GAME_ID == 0x4748454A || isPSO)
+		else if(TITLE_ID == 0x474845 || isPSO)
 			bbaEmuWanted = 2;
 	}
 	else
@@ -3885,7 +3885,7 @@ void DoPatches( char *Buffer, u32 Length, u32 DiscOffset )
 			write32(SO_HSP_LOC+0x18, SOShift << 16 | SOCurrentTotalFDs);
 			write32(SO_HSP_LOC+0x1C, 0); //needs to be inited
 			sync_after_write((void*)SO_HSP_LOC, 0x20);
-			if(GAME_ID == 0x4748454A)
+			if(TITLE_ID == 0x474845)
 			{
 				if(read32(0x6E88) == 0x4804E39D)
 				{
@@ -3901,7 +3901,7 @@ void DoPatches( char *Buffer, u32 Length, u32 DiscOffset )
 				}
 			}
 		}
-		else if(GAME_ID == 0x4748454A && read32(0x5DD4) == 0x480AF13D)
+		else if(TITLE_ID == 0x474845 && read32(0x5DD4) == 0x480AF13D)
 		{
 			write32(0x5DCC, 0x3C600402);
 			write32(0x5DD0, 0x60630200);


### PR DESCRIPTION
Support for new game translations by DOL Translations.

In-development translations of HomeLand (GHEJ91) and Nintendo Puzzle Collection (GPZJ01) will use NTSC-U region encoding and new TitleIDs: GHEE91 & GPZE01. Translations do not modify the render pipeline or similar, and should work with existing settings and patches for their Japanese counterparts.

This commit replaces the region-specific checks with the more general ones used by multi-region games.