### PR TITLE
Fix Wii U adapter clone not working in Wii U mode

### DIFF
--- a/kernel/HID.c
+++ b/kernel/HID.c
@@ -724,6 +724,9 @@ static s32 HIDInterruptMessage(u32 isKBreq, u8 *Data, u32 Length, u32 Endpoint, 
 }
 void HIDGCInit()
 {
+	// Needed for some adapters clone
+	HIDControlMessage(0, NULL, 0, USB_REQTYPE_INTERFACE_SET, USB_REQ_SETPROTOCOL, 1, 0, NULL);
+
 	s32 ret = HIDInterruptMessage(0, gcbuf, 1, bEndpointAddressOut, 0, NULL);
 	if( ret < 0 )
 	{


### PR DESCRIPTION
I have a clone adapter with USB id 0079:1846 when configured in PC mode. It was not working in Wii U mode in Nintendont on a Wii. Adding this control transfer during initialisation make it work. I think it is harmless for other adapters but I cannot be sure as original adapters are very hard to find at a decent price. 