### PR TITLE
Ignore "Memcard Emulation" when running a Triforce game

### DIFF
--- a/loader/source/main.c
+++ b/loader/source/main.c
@@ -1681,4 +1681,3 @@ int main(int argc, char **argv)
 
 	return 0;
 }
-


### PR DESCRIPTION
This will prevent Nintendont from creating a useless Memory Card file when running one of these games.