### PR TITLE
Fix Broadband Adapter Emulation for Homeland

### DIFF
--- a/loader/source/ppc/IOSInterface/source/sock.c
+++ b/loader/source/ppc/IOSInterface/source/sock.c
@@ -1037,6 +1037,7 @@ static void threadHandleNew(myCtx *ctx)
 						u32 cb = threadReqDat[type][pool].cb;
 						u32 sock = threadReqDat[type][pool].sock;
 						if(type == T_SEND) {
+							threadInUse[type][pool] = 0;
 							((send_cb)cb)(0, sock);
 						}
 						else if(type == T_RECV)
@@ -1302,7 +1303,7 @@ int tcp_accept(short sock, u32 cb, u32 bufmaybe)
 	test_debug("tcp_accept",0,0,0,0);
 	if(cb)
 	{
-		if (test_socket(T_ACPT,sock)==0) return 0;	//already something pending
+		if (test_socket(T_ACPT,sock)==0) return -1;	//already something pending
 		if(!lockThread(T_ACPT)) return -1;
 		int fd = getFreeFD();
 		threadInUse[T_ACPT][fd] = 1;	//reserve it
@@ -1334,7 +1335,7 @@ int tcp_send(int sock, u32 cb, int pcks, sendarr *arr)
 		threadInUse[T_SEND][fd] = 3;
 		OSWakeupThread(&so_queue[SO_THREAD_FD|so_sendto]);
 		unlockThread(T_SEND);
-		return 0;
+		return -1;
 	}
 	int i;
 	for(i = 0; i < pcks; i++){
@@ -1352,7 +1353,7 @@ int tcp_receive(int sock, u32 cb, u32 len, char *buf)
 	
 	if(cb)
 	{
-		if (test_socket(T_RECV,sock)==0) return 0;	//already something pending
+		if (test_socket(T_RECV,sock)==0) return -1;	//already something pending
 		if(!lockThread(T_RECV)) return -1;
 		int fd = getFreeFD();
 		threadInUse[T_RECV][fd] = 1;
@@ -1363,7 +1364,7 @@ int tcp_receive(int sock, u32 cb, u32 len, char *buf)
 		threadInUse[T_RECV][fd] = 3;
 		OSWakeupThread(&so_queue[SO_THREAD_FD|so_recvfrom]);
 		unlockThread(T_RECV);
-		return 0;
+		return -1;
 	}
 	int ret = SORecvFrom(sock, buf, len, 0, 0);
 


### PR DESCRIPTION
Fixes connection issue introduced in commit ecbe6f9 when connecting to the server in Homeland
tested with Homeland, Kirby Air Ride and Mario Kart: Double Dash!!

Edit: Removed vague wording.